### PR TITLE
Introduce smart scrolling on the map

### DIFF
--- a/assets/javascripts/tkgmap_application.js
+++ b/assets/javascripts/tkgmap_application.js
@@ -3,6 +3,7 @@
     function initMap(lat, lng, fixedCenter, zoom) {
       var latlng = new google.maps.LatLng(lat, lng);
       var opts = {
+        gestureHandling: "auto",
         zoom: (zoom === undefined)? 8 : zoom,
         mapTypeId: google.maps.MapTypeId.ROADMAP,
         center: latlng


### PR DESCRIPTION
This PR sets `gestureHandling` to `"auto"` i.e. ignores one-finger touch gestures by the Google Map.

 * Elena Kelareva, "[Smart scrolling comes to mobile web maps](https://maps-apis.googleblog.com/2016/11/smart-scrolling-comes-to-mobile-web-maps.html)", Google Geo Developers Blog, Nov 2016
 * "[Google Maps API 新機能：スマートなスクロール機能をモバイル ウェブ マップに導入](https://cloud-ja.googleblog.com/2016/11/google-maps-api_25.html)", Google Cloud Japan 公式ブログ, Nov 2016 (JAPANESE)
