### PR TITLE
Support redmine v3.4.x

### DIFF
--- a/lib/issues_helper_patch.rb
+++ b/lib/issues_helper_patch.rb
@@ -49,29 +49,28 @@ module IssuesHelperPatch
 
 		if Gem::Version.new([Redmine::VERSION::MAJOR, Redmine::VERSION::MINOR].join(".")) >= Gem::Version.new("3.4") # redmine >= 3.4
 
-		def render_half_width_custom_fields_rows(issue)
-			values = issue.try(:visible_custom_field_values) || issue.custom_field_values
-			return if values.empty?
-			half = (values.size / 2.0).ceil
-			issue_fields_rows do |rows|
-				values.each_with_index do |value, i|
-					sv = (value.custom_field.field_format == Tkgmap::Identifier)? show_tkgmap_value(value) : show_value(value)
+			def render_half_width_custom_fields_rows(issue)
+				values = issue.try(:visible_custom_field_values) || issue.custom_field_values
+				return if values.empty?
+				half = (values.size / 2.0).ceil
+				issue_fields_rows do |rows|
+					values.each_with_index do |value, i|
+						sv = (value.custom_field.field_format == Tkgmap::Identifier)? show_tkgmap_value(value) : show_value(value)
 
-					css = "cf_#{value.custom_field.id}".dup
-					css << ' tkgmap' if value.custom_field.field_format == Tkgmap::Identifier
-					m = (i < half ? :left : :right)
-					rows.send m, custom_field_name_tag(value.custom_field), sv, :class => css
+						css = "cf_#{value.custom_field.id}".dup
+						css << ' tkgmap' if value.custom_field.field_format == Tkgmap::Identifier
+						m = (i < half ? :left : :right)
+						rows.send m, custom_field_name_tag(value.custom_field), sv, :class => css
+					end
 				end
 			end
-		end
 
-		else # redmine < 3.4
+		elsif Gem::Version.new([Redmine::VERSION::MAJOR, Redmine::VERSION::MINOR].join(".")) >= Gem::Version.new("3.2") # redmine >= 3.2
 
-		def render_custom_fields_rows_with_tkg(issue)
-			values = issue.try(:visible_custom_field_values) || issue.custom_field_values
-			return if values.empty?
+			def render_custom_fields_rows_with_tkg(issue)
+				values = issue.try(:visible_custom_field_values) || issue.custom_field_values
+				return if values.empty?
 
-			if Gem::Version.new([Redmine::VERSION::MAJOR, Redmine::VERSION::MINOR].join(".")) >= Gem::Version.new("3.2") # redmine >= 3.2
 				half = (values.size / 2.0).ceil
 
 				issue_fields_rows do |rows|
@@ -88,7 +87,13 @@ module IssuesHelperPatch
 						rows.send m, custom_field_name_tag(value.custom_field), sv, :class => css
 					end
 				end
-			else # redmine < 3.2
+			end
+		else # redmine < 3.2
+
+			def render_custom_fields_rows_with_tkg(issue)
+				values = issue.try(:visible_custom_field_values) || issue.custom_field_values
+				return if values.empty?
+
 				ordered_values = []
 				half = (values.size / 2.0).ceil
 				half.times do |i| 
@@ -112,7 +117,6 @@ module IssuesHelperPatch
 				s << "</tr>\n"
 				s.html_safe
 			end
-		end
 		end
 
 	end

--- a/lib/issues_helper_patch.rb
+++ b/lib/issues_helper_patch.rb
@@ -2,9 +2,13 @@ require_dependency 'issues_helper'
 
 module IssuesHelperPatch
 	def self.included(base)
-		base.send(:include, InstanceMethods)
-		base.class_eval do
-			alias_method_chain :render_custom_fields_rows, :tkg
+		if Gem::Version.new([Redmine::VERSION::MAJOR, Redmine::VERSION::MINOR].join(".")) >= Gem::Version.new("3.4") # redmine >= 3.4
+			base.send(:prepend, InstanceMethods)
+		else
+			base.send(:include, InstanceMethods)
+			base.class_eval do
+				alias_method_chain :render_custom_fields_rows, :tkg
+			end
 		end
 	end
 
@@ -24,7 +28,7 @@ module IssuesHelperPatch
 					safe_join header_tags
 				end
 
-				s = ''
+				s = String.new
 				latLng = sv.split(",")
 				default_zoom = 'undefined'
 				default_zoom = Setting.plugin_redmine_tkgmap['default_zoom'].to_i if default_zoom.present?
@@ -43,6 +47,26 @@ module IssuesHelperPatch
 		end
 		private :show_tkgmap_value
 
+		if Gem::Version.new([Redmine::VERSION::MAJOR, Redmine::VERSION::MINOR].join(".")) >= Gem::Version.new("3.4") # redmine >= 3.4
+
+		def render_half_width_custom_fields_rows(issue)
+			values = issue.try(:visible_custom_field_values) || issue.custom_field_values
+			return if values.empty?
+			half = (values.size / 2.0).ceil
+			issue_fields_rows do |rows|
+				values.each_with_index do |value, i|
+					sv = (value.custom_field.field_format == Tkgmap::Identifier)? show_tkgmap_value(value) : show_value(value)
+
+					css = "cf_#{value.custom_field.id}".dup
+					css << ' tkgmap' if value.custom_field.field_format == Tkgmap::Identifier
+					m = (i < half ? :left : :right)
+					rows.send m, custom_field_name_tag(value.custom_field), sv, :class => css
+				end
+			end
+		end
+
+		else # redmine < 3.4
+
 		def render_custom_fields_rows_with_tkg(issue)
 			values = issue.try(:visible_custom_field_values) || issue.custom_field_values
 			return if values.empty?
@@ -58,7 +82,7 @@ module IssuesHelperPatch
 							sv = simple_format_without_paragraph(h(show_value(value)))
 						end
 
-						css = "cf_#{value.custom_field.id}"
+						css = "cf_#{value.custom_field.id}".dup
 						css << ' tkgmap' if value.custom_field.field_format == Tkgmap::Identifier
 						m = (i < half ? :left : :right)
 						rows.send m, custom_field_name_tag(value.custom_field), sv, :class => css
@@ -71,7 +95,7 @@ module IssuesHelperPatch
 					ordered_values << values[i]
 					ordered_values << values[i + half]
 				end 
-				s = "<tr>\n"
+				s = "<tr>\n".dup
 				n = 0 
 				ordered_values.compact.each do |value|
 					sv = ""
@@ -89,6 +113,8 @@ module IssuesHelperPatch
 				s.html_safe
 			end
 		end
+		end
+
 	end
 end
 


### PR DESCRIPTION
This PR makes the plugin compatible with redmine 3.4.x.

 * `IssueHelper#render_custom_fields_rows` methods no longer exist since redmine 3.4.0. Thesefore, the `IssueHelperPatch` fails and raises an error. (ref. https://www.redmine.org/issues/21705 )
 * This PR follows this redmine change with keeping compatibility with older redmine versions.
