### PR TITLE
fix a bug where google maps api key does not contain on issue page

### DIFF
--- a/lib/issues_helper_patch.rb
+++ b/lib/issues_helper_patch.rb
@@ -24,7 +24,7 @@ module IssuesHelperPatch
 					end
 					header_tags << javascript_include_tag('tkgmap_application',:plugin => 'redmine_tkgmap')
 					header_tags << javascript_include_tag('showMapWindow',:plugin => 'redmine_tkgmap')
-					header_tags << content_tag("script", "",{:src =>'https://maps.google.com/maps/api/js?v=3&sensor=false', :type =>'text/javascript', :charset=>'UTF-8'})
+					header_tags << content_tag("script", "",{:src =>TkgmapController.helpers.gmap_api_uri, :type =>'text/javascript', :charset=>'UTF-8'})
 					safe_join header_tags
 				end
 


### PR DESCRIPTION
I have introduced Google Maps API Key in a part of PR shota-kobayashi/redmine_tkgmap#11 .
However, I found that this work was acutually incomplete: the api key does not contain on the issue page.

This PR fixes this bug.