### PR TITLE
Support for Redmine4

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 # Plugin's routes
 # See: http://guides.rubyonrails.org/routing.html
 Rails.application.routes.draw do
-  get 'tkgmap/:action', :controller => 'tkgmap', :via => [:get, :post]
+  get 'tkgmap', :to => 'tkgmap#index'
+  get 'tkgmap/window', :to => 'tkgmap#window'
 end

--- a/init.rb
+++ b/init.rb
@@ -4,8 +4,8 @@ require 'issues_helper_patch'
 Redmine::Plugin.register :redmine_tkgmap do
   name 'Redmine Tkgmap plugin'
   author 'Shota.K'
-  description 'Adding lat lng chooser with google map.(Redmine 2.3, 2,2...)'
-  version '0.1'
+  description 'Adding lat lng chooser with google map.'
+  version '0.2.0'
   url 'https://github.com/shota-kobayashi/redmine_tkgmap'
   author_url 'https://github.com/shota-kobayashi/redmine_tkgmap'
 

--- a/lib/custom_fields_helper_patch.rb
+++ b/lib/custom_fields_helper_patch.rb
@@ -2,26 +2,23 @@ require_dependency 'custom_fields_helper'
 
 module CustomFieldsHelperPatch
 	def self.included(base)
-		base.send(:include, InstanceMethods)
-		base.class_eval do
-			alias_method_chain :custom_field_tag, :tkg
-		end
+		base.send(:prepend, InstanceMethods)
 	end
 
 	module InstanceMethods
-		def custom_field_tag_with_tkg(name, custom_value)
+		def custom_field_tag(name, custom_value)
 			
 			custom_field = custom_value.custom_field
 			field_format = Redmine::FieldFormat.find(custom_field.field_format)
 			if field_format.format_name == "tkg"
-				s = custom_field_tag_without_tkg(name, custom_value)
+				s = super(name, custom_value)
 				windowWidth = Setting.plugin_redmine_tkgmap['map_width'].to_i + 30
 				windowHeight = Setting.plugin_redmine_tkgmap['map_height'].to_i + 30
 				customFieldId = "#{name}_custom_field_values_#{custom_field.id}"
 				s << javascript_include_tag('showMapWindow',:plugin => 'redmine_tkgmap')
 				s << content_tag("input", "", {:type => 'button', :onClick =>"showMapWindow(\"#{url_for(:controller => 'tkgmap', :action => 'window')}\", \"#{customFieldId}\", #{windowWidth}, #{windowHeight});", :value=>l(:set_lat_lng_tkg)})
 			else
-				s = custom_field_tag_without_tkg(name, custom_value)
+				s = super(name, custom_value)
 			end
 		end
 	end

--- a/lib/issues_helper_patch.rb
+++ b/lib/issues_helper_patch.rb
@@ -2,14 +2,7 @@ require_dependency 'issues_helper'
 
 module IssuesHelperPatch
 	def self.included(base)
-		if Gem::Version.new([Redmine::VERSION::MAJOR, Redmine::VERSION::MINOR].join(".")) >= Gem::Version.new("3.4") # redmine >= 3.4
-			base.send(:prepend, InstanceMethods)
-		else
-			base.send(:include, InstanceMethods)
-			base.class_eval do
-				alias_method_chain :render_custom_fields_rows, :tkg
-			end
-		end
+		base.send(:prepend, InstanceMethods)
 	end
 
 	module InstanceMethods
@@ -67,7 +60,7 @@ module IssuesHelperPatch
 
 		elsif Gem::Version.new([Redmine::VERSION::MAJOR, Redmine::VERSION::MINOR].join(".")) >= Gem::Version.new("3.2") # redmine >= 3.2
 
-			def render_custom_fields_rows_with_tkg(issue)
+			def render_custom_fields_rows(issue)
 				values = issue.try(:visible_custom_field_values) || issue.custom_field_values
 				return if values.empty?
 
@@ -90,7 +83,7 @@ module IssuesHelperPatch
 			end
 		else # redmine < 3.2
 
-			def render_custom_fields_rows_with_tkg(issue)
+			def render_custom_fields_rows(issue)
 				values = issue.try(:visible_custom_field_values) || issue.custom_field_values
 				return if values.empty?
 


### PR DESCRIPTION
This PR makes the plugin compatible with redmine 4.0.x (based on rails 5.2).

* `alias_method_chain` is replaced with `prepend`.
  * `alias_method_chain` has been removed in rails 5.1.
  * I believe there is no longer worthwhile to write code that works with both alias_method_chain and prepend because Ruby 1.9 is too old and no longer used. So, I decided remove alias_method_chain code and it means dropping support for ruby 1.9.
  * This PR would resolve #17.
* Bump version to v0.2.0. I believe it is a good time to version up because it contains "Incompatible Changes" -- dropping support for ruby 1.9.
* This PR follows this redmine change with keeping compatibility with older redmine versions.
