### PR TITLE
support for redmine6

### DIFF
--- a/app/controllers/tkgmap_controller.rb
+++ b/app/controllers/tkgmap_controller.rb
@@ -1,5 +1,5 @@
 class TkgmapController < ApplicationController
-  unloadable
+  unloadable if respond_to?(:unloadable)
   layout 'tkgmap'
 
   def index


### PR DESCRIPTION
make unloadable call only if unloadable exists.

Redmine 6 bumped rails version to 7. Rails 7 has removed unloadable and no longer required in Rails7. To keep compatibility with legacy versions, leave call it if present.